### PR TITLE
Update PCSD Makefile for GNU/Linux

### DIFF
--- a/pcsd/Makefile
+++ b/pcsd/Makefile
@@ -1,9 +1,25 @@
+# This doesn't work for GNU/Linux.
 REL_INFO := $(shell grep -q -i "release 6" /etc/redhat-release ; echo $$?)
 
-ifeq (${REL_INFO},1)
-  build_gems: build_gems_normal
+# To support GNU/Linux, specifically Debian     
+UNAME_OS_GNU := $(shell if uname -o | grep -q "GNU/Linux" ; then echo 0; else echo 1; fi)
+UNAME_KERNEL_DEBIAN := $(shell if uname -v | grep -q "Debian" ; then echo 0; else echo 1; fi)
+UNAME_DEBIAN_VER_8 := $(shell if grep -q -i "8" /etc/debian_version ; then echo 0; else echo 1; fi)
+
+ifeq (${UNAME_OS_GNU},0)    
+  ifeq (${UNAME_KERNEL_DEBIAN},0)
+    ifeq (${UNAME_DEBIAN_VER_8},0)
+      build_gems: build_gems_normal
+    else
+      build_gems: build_gems_normal
+    endif
+  endif
 else
-  build_gems: build_gems_rhel6
+  ifeq (${REL_INFO},1)
+    build_gems: build_gems_normal
+  else
+    build_gems: build_gems_rhel6
+  endif
 endif
 
 build_gems_normal:


### PR DESCRIPTION
- Provided support for building PCSD on GNU/Linux, specifically Debian.

[NOTES]
- Tested on Debian Jessie, with Pacemaker 1.11 and Corosync 2.x from experimental.
- I did not use sudo for make get_gems in the pcsd directory, this worked fine as non-root.
- I had to run sudo make install, and sudo make install_pcsd in order  to get privileges to create directories and copy files.
- I had to run sudo systemctl daemon-reload
- A warning is displayed when you sudo make install_pcsd from ruby, explaining not to install gems as the
  root user...this was unavoidable for me - but I'm new to Ruby, perhaps there is a way to avoid that.
- Using sudo should not be too much of a problem on Debian, as you can only use Pacemaker and
  Corosync as root anyhow.  File permission changes would be necessary through the whole cluster stack.
- I left an additional else in the ifeq blocks for Debian, to provide a sort of place-holder for helping them to
  support additional distribution versions, since I didn't do any extensive testing.