### PR TITLE
Rikkotec Github and pcsd Makefile Patch

### DIFF
--- a/README
+++ b/README
@@ -33,4 +33,7 @@ You can also install pcsd which operates as a GUI and remote server for pcs.  To
 # cd pcsd ; make get_gems ; cd ..
 # make install_pcsd
 
+If you are using GNU/Linux its now time to:
+# systemctl daemon-reload
+
 If you have an questions or concerns please feel free to email cfeist@redhat.com or open a github issue on the pcs project.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# PCS - Pacemaker/Corosync configuration system
+
+
+## Quick Start
+
+
+#### PCS Installation from Source
+
+Run the following in terminal:
+
+```shell
+# tar -xzvf pcs-0.9.138.tar.gz
+# cd pcs-0.9.138
+# make install
+```
+
+This will install pcs into `/usr/sbin/pcs`. You may have to use *sudo* for `make install` to work.
+
+
+#### Create a Basic Cluster
+
+To create a cluster run the following commands on all nodes (replacing node1, node2, node3 with a list of nodes in the cluster). You may need to use *sudo* to have this work.
+
+```shell
+# pcs cluster setup --local --name cluster_name node1 node2 node3
+```
+
+Then run the following command on all nodes, and again you may need to use *sudo*:
+
+```
+# pcs cluster start
+```
+
+After a few moments the cluster should startup and you can get the status of the cluster
+
+```shell
+# pcs status
+```
+
+After this you can add resources and stonith agents:
+
+```shell
+# pcs resource help
+```
+and
+
+```shell
+# pcs stonith help
+```
+
+Currently this is built into Fedora (other distributions to follow).  You can
+see the current Fedora .spec in the fedora package git repositories here:
+http://pkgs.fedoraproject.org/cgit/pcs.git/
+
+Current Fedora 18 .spec:
+http://pkgs.fedoraproject.org/cgit/pcs.git/tree/pcs.spec?h=f18
+
+
+#### PCS Installation from Source
+
+You can also install pcsd which operates as a GUI and remote server for pcs. It is also necessary to follow the guides on the clusterlabs.org website.  
+
+To install pcsd run the following commands from the root of your pcs directory. (You must have the ruby bundler gem installed, rubygem-bundler in Fedora, and development packages installed)
+
+```shell
+# cd pcsd ; make get_gems ; cd ..
+# make install_pcsd
+```
+
+If you are on GNU/Linux its time to:
+
+```shell
+# systemctl daemon-reload
+```
+
+
+## Inquiries
+
+If you have an questions or concerns please feel free to email cfeist@redhat.com or open a github issue on the pcs project.

--- a/README.md
+++ b/README.md
@@ -26,44 +26,45 @@
    # pcs cluster setup --local --name cluster_name node1 node2 node3
    ```
 
-<br />
    Then run the following command on all nodes:
 
    ```shell
    # pcs cluster start
    ```
 
+<br />
 - **Check the Cluster Status**
+
    After a few moments the cluster should startup and you can get the status of the cluster
 
    ```shell
    # pcs status
    ```
 
-- **Add a Cluster Reosurce
+<br />
+- **Add a Cluster Reosurce**
+
    After this you can add resources and stonith agents:
 
    ```shell
    # pcs resource help
    ```
+
    and
 
    ```shell
    # pcs stonith help
    ```
 
-<br />
-   Currently this is built into Fedora (other distributions to follow).  You can
-   see the current Fedora .spec in the fedora package git repositories here:
-   http://pkgs.fedoraproject.org/cgit/pcs.git/
+   Currently this is built into Fedora (other distributions to follow).  You can see the current Fedora .spec in the fedora package git repositories here: http://pkgs.fedoraproject.org/cgit/pcs.git/
 
-   Current Fedora 18 .spec:
+   Current Fedora 18 .spec:   
    http://pkgs.fedoraproject.org/cgit/pcs.git/tree/pcs.spec?h=f18
 
-
+<br />
 - **PCSD Installation from Source**
 
-   You can also install pcsd which operates as a GUI and remote server for pcs. pcsd may also necessary in order to follow the guides on the clusterlabs.org website.  
+   You can also install pcsd which operates as a GUI and remote server for pcs. pcsd may also necessary in order to follow the guides on the clusterlabs.org website.
 
    To install pcsd run the following commands from the root of your pcs directory. (You must have the ruby bundler gem installed, rubygem-bundler in Fedora, and development packages installed)
 
@@ -72,7 +73,6 @@
    # make install_pcsd
    ```
 
-<br />
    If you are on GNU/Linux its time to:
 
    ```shell

--- a/README.md
+++ b/README.md
@@ -2,78 +2,85 @@
 
 
 ### Quick Start
+***
 
 
-##### PCS Installation from Source
+- **PCS Installation from Source**
 
-Run the following in terminal:
+   Run the following in terminal:
+  
+   ```shell
+   # tar -xzvf pcs-0.9.138.tar.gz
+   # cd pcs-0.9.138
+   # make install
+   ```
 
-```shell
-# tar -xzvf pcs-0.9.138.tar.gz
-# cd pcs-0.9.138
-# make install
-```
+   This will install pcs into `/usr/sbin/pcs`.
 
-This will install pcs into `/usr/sbin/pcs`.
+<br />
+- **Create and Start a Basic Cluster**
 
+   To create a cluster run the following commands on all nodes (replacing node1, node2, node3 with a list of nodes in the cluster).
 
-##### Create a Basic Cluster
+   ```shell
+   # pcs cluster setup --local --name cluster_name node1 node2 node3
+   ```
 
-To create a cluster run the following commands on all nodes (replacing node1, node2, node3 with a list of nodes in the cluster).
+<br />
+   Then run the following command on all nodes:
 
-```shell
-# pcs cluster setup --local --name cluster_name node1 node2 node3
-```
+   ```shell
+   # pcs cluster start
+   ```
 
-Then run the following command on all nodes:
+- **Check the Cluster Status**
+   After a few moments the cluster should startup and you can get the status of the cluster
 
-```shell
-# pcs cluster start
-```
+   ```shell
+   # pcs status
+   ```
 
-After a few moments the cluster should startup and you can get the status of the cluster
+- **Add a Cluster Reosurce
+   After this you can add resources and stonith agents:
 
-```shell
-# pcs status
-```
+   ```shell
+   # pcs resource help
+   ```
+   and
 
-After this you can add resources and stonith agents:
+   ```shell
+   # pcs stonith help
+   ```
 
-```shell
-# pcs resource help
-```
-and
+<br />
+   Currently this is built into Fedora (other distributions to follow).  You can
+   see the current Fedora .spec in the fedora package git repositories here:
+   http://pkgs.fedoraproject.org/cgit/pcs.git/
 
-```shell
-# pcs stonith help
-```
-
-Currently this is built into Fedora (other distributions to follow).  You can
-see the current Fedora .spec in the fedora package git repositories here:
-http://pkgs.fedoraproject.org/cgit/pcs.git/
-
-Current Fedora 18 .spec:
-http://pkgs.fedoraproject.org/cgit/pcs.git/tree/pcs.spec?h=f18
-
-
-##### PCSD Installation from Source
-
-You can also install pcsd which operates as a GUI and remote server for pcs. pcsd may also necessary in order to follow the guides on the clusterlabs.org website.  
-
-To install pcsd run the following commands from the root of your pcs directory. (You must have the ruby bundler gem installed, rubygem-bundler in Fedora, and development packages installed)
-
-```shell
-# cd pcsd ; make get_gems ; cd ..
-# make install_pcsd
-```
-
-If you are on GNU/Linux its time to:
-
-```shell
-# systemctl daemon-reload
-```
+   Current Fedora 18 .spec:
+   http://pkgs.fedoraproject.org/cgit/pcs.git/tree/pcs.spec?h=f18
 
 
+- **PCSD Installation from Source**
+
+   You can also install pcsd which operates as a GUI and remote server for pcs. pcsd may also necessary in order to follow the guides on the clusterlabs.org website.  
+
+   To install pcsd run the following commands from the root of your pcs directory. (You must have the ruby bundler gem installed, rubygem-bundler in Fedora, and development packages installed)
+
+   ```shell
+   # cd pcsd ; make get_gems ; cd ..
+   # make install_pcsd
+   ```
+
+<br />
+   If you are on GNU/Linux its time to:
+
+   ```shell
+   # systemctl daemon-reload
+   ```
+
+<br />
 ### Inquiries
+***
 
-If you have an questions or concerns please feel free to email cfeist@redhat.com or open a github issue on the pcs project.
+If you have any questions or concerns please feel free to email cfeist@redhat.com or open a github issue on the pcs project.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# PCS - Pacemaker/Corosync configuration system
+## PCS - Pacemaker/Corosync configuration system
 
 
-## Quick Start
+### Quick Start
 
 
-#### PCS Installation from Source
+##### PCS Installation from Source
 
 Run the following in terminal:
 
@@ -14,20 +14,20 @@ Run the following in terminal:
 # make install
 ```
 
-This will install pcs into `/usr/sbin/pcs`. You may have to use *sudo* for `make install` to work.
+This will install pcs into `/usr/sbin/pcs`.
 
 
-#### Create a Basic Cluster
+##### Create a Basic Cluster
 
-To create a cluster run the following commands on all nodes (replacing node1, node2, node3 with a list of nodes in the cluster). You may need to use *sudo* to have this work.
+To create a cluster run the following commands on all nodes (replacing node1, node2, node3 with a list of nodes in the cluster).
 
 ```shell
 # pcs cluster setup --local --name cluster_name node1 node2 node3
 ```
 
-Then run the following command on all nodes, and again you may need to use *sudo*:
+Then run the following command on all nodes:
 
-```
+```shell
 # pcs cluster start
 ```
 
@@ -56,9 +56,9 @@ Current Fedora 18 .spec:
 http://pkgs.fedoraproject.org/cgit/pcs.git/tree/pcs.spec?h=f18
 
 
-#### PCS Installation from Source
+##### PCSD Installation from Source
 
-You can also install pcsd which operates as a GUI and remote server for pcs. It is also necessary to follow the guides on the clusterlabs.org website.  
+You can also install pcsd which operates as a GUI and remote server for pcs. pcsd may also necessary in order to follow the guides on the clusterlabs.org website.  
 
 To install pcsd run the following commands from the root of your pcs directory. (You must have the ruby bundler gem installed, rubygem-bundler in Fedora, and development packages installed)
 
@@ -74,6 +74,6 @@ If you are on GNU/Linux its time to:
 ```
 
 
-## Inquiries
+### Inquiries
 
 If you have an questions or concerns please feel free to email cfeist@redhat.com or open a github issue on the pcs project.


### PR DESCRIPTION
Beyond adding support for GNU/Linux to the pcsd Makfile, this patch also adds a README.md to the source, which Github favors over README - and which presents a prettier and more readable documentation via the Github.com web project interface with updated documentation.

The README file was also updated to include additional information for GNU/Linux users in the pcsd installation steps.